### PR TITLE
UPDATE: aamod_coreg_extended_1 (T1 to MNI, within-modality) uses ncc as default cost function

### DIFF
--- a/aa_modules/aamod_coreg_extended_1.xml
+++ b/aa_modules/aamod_coreg_extended_1.xml
@@ -11,7 +11,7 @@
             <permanenceofoutput>2</permanenceofoutput>
             
             <eoptions>
-                <cost_fun>nmi</cost_fun>
+                <cost_fun>ncc</cost_fun>
             </eoptions>
             
             <inputstreams>


### PR DESCRIPTION
See commit.