### PR TITLE
Dprice80 empty mask patch

### DIFF
--- a/aa_modules/aamod_mask_fromsegment.m
+++ b/aa_modules/aamod_mask_fromsegment.m
@@ -80,7 +80,7 @@ switch task
                     Y{a} = Y{a} > thr(a);
                     
                     if numel(Y{a} > 0) == 0 % check for bad thesholding
-                        aas_log(aap, true, sprintf('ERROR: No voxels below the threshold mask (%f) [max: %f]', thr(a), maxY))
+                        aas_log(aap, true, sprintf('ERROR: No voxels above the threshold mask (%f) [max: %f]', thr(a), maxY))
                     end
                     
                     V{a}.fname = spm_file(segimg(a,:),'prefix','S_r');

--- a/aa_modules/aamod_mask_fromsegment.m
+++ b/aa_modules/aamod_mask_fromsegment.m
@@ -76,10 +76,11 @@ switch task
                 thr = aas_getsetting(aap,'threshold');
                 if numel(thr) == 1, thr(1:3) = thr; end
                 for a = 1:size(segimg,1)
+                    maxY = max(Y{a}(:));
                     Y{a} = Y{a} > thr(a);
                     
                     if isempty(find(Y{a},1,'first')) % check for bad thesholding
-                        aas_log(aap, true, sprintf('ERROR: No voxels below the threshold mask (%f)', thr(a)))
+                        aas_log(aap, true, sprintf('ERROR: No voxels below the threshold mask (%f) [max: %f]', thr(a), maxY))
                     end
                     
                     V{a}.fname = spm_file(segimg(a,:),'prefix','S_r');

--- a/aa_modules/aamod_mask_fromsegment.m
+++ b/aa_modules/aamod_mask_fromsegment.m
@@ -79,7 +79,7 @@ switch task
                     maxY = max(Y{a}(:));
                     Y{a} = Y{a} > thr(a);
                     
-                    if isempty(find(Y{a},1,'first')) % check for bad thesholding
+                    if numel(Y{a} > 0) == 0 % check for bad thesholding
                         aas_log(aap, true, sprintf('ERROR: No voxels below the threshold mask (%f) [max: %f]', thr(a), maxY))
                     end
                     

--- a/aa_modules/aamod_mask_fromsegment.m
+++ b/aa_modules/aamod_mask_fromsegment.m
@@ -77,7 +77,11 @@ switch task
                 if numel(thr) == 1, thr(1:3) = thr; end
                 for a = 1:size(segimg,1)
                     Y{a} = Y{a} > thr(a);
-
+                    
+                    if isempty(find(Y{a},1,'first')) % check for bad thesholding
+                        aas_log(aap, true, sprintf('ERROR: No voxels below the threshold mask (%f)', thr(a)))
+                    end
+                    
                     V{a}.fname = spm_file(segimg(a,:),'prefix','S_r');
                     outstream = strvcat(outstream, V{a}.fname); % Save to stream...
                     spm_write_vol(V{a}, Y{a});

--- a/aa_modules/aamod_mask_fromstruct.m
+++ b/aa_modules/aamod_mask_fromstruct.m
@@ -147,6 +147,11 @@ switch task
         for a = 1:size(SEGimg,1)
             [pth, fn, ext] = fileparts(SEGimg(a,:));
             
+            maxY = max(Y{a}(:));
+            if numel(Y{a} > 0) == 0 % check for bad thesholding
+                aas_log(aap, true, sprintf('ERROR: No voxels above the threshold mask (%f) [max: %f]', thr(a), maxY))
+            end
+            
             if ~isempty(strfind(fn(1), 'w'))
                 eY = WeY == a;
             else


### PR DESCRIPTION
aa_modules/aamod_mask_fromsegment.m and aa_modules/aamod_mask_fromstruct.m should throw an error if the mask is empty. This prevents error messages downstream that are harder to diagnose.